### PR TITLE
NameTemplate not overwritten for Paper

### DIFF
--- a/Models/Minecraft/Paper/PaperManifest.cs
+++ b/Models/Minecraft/Paper/PaperManifest.cs
@@ -33,7 +33,7 @@ namespace TCAdminCrons.Models.Minecraft.Paper
             
             var variables = new Dictionary<string, object>
             {
-                {"Update.Version", version}
+                {"Update", version}
             };
             
             var gameUpdate = new GameUpdate


### PR DESCRIPTION
Tried running on a test setup and all Paper versions were downloaded but the NameTemplate was never set 

![image](https://user-images.githubusercontent.com/40238062/91065595-f915de00-e630-11ea-9ccd-ff54f39dab6d.png)
